### PR TITLE
feat: ignore more pydantic methods and allow cleaning directory

### DIFF
--- a/sphinx_ape/_base.py
+++ b/sphinx_ape/_base.py
@@ -14,8 +14,12 @@ class Documentation:
         return self._base_path / "docs"
 
     @property
+    def root_build_path(self) -> Path:
+        return self.docs_path / "_build"
+
+    @property
     def build_path(self) -> Path:
-        return self.docs_path / "_build" / self._name
+        return self.root_build_path / self._name
 
     @property
     def latest_path(self) -> Path:

--- a/sphinx_ape/_cli.py
+++ b/sphinx_ape/_cli.py
@@ -154,6 +154,16 @@ def publish(base_path, mode, repo, skip_push):
         sys.exit(1)
 
 
+@cli.command()
+@click.argument("base_path", type=Path)
+def clean(base_path):
+    """
+    Delete build artifacts
+    """
+    builder = _create_builder(base_path=base_path)
+    builder.clean()
+
+
 def _create_builder(*args, **kwargs) -> DocumentationBuilder:
     # Abstracted for testing purposes.
     return DocumentationBuilder(*args, **kwargs)

--- a/sphinx_ape/build.py
+++ b/sphinx_ape/build.py
@@ -104,6 +104,9 @@ class DocumentationBuilder(Documentation):
 
         self._setup_redirect()
 
+    def clean(self):
+        shutil.rmtree(self.root_build_path)
+
     def publish(self, repository: Optional[str] = None, push: bool = True):
         """
         Publish the documentation to GitHub pages.

--- a/sphinx_ape/sphinx_ext/plugin.py
+++ b/sphinx_ape/sphinx_ext/plugin.py
@@ -83,6 +83,17 @@ def setup(app: Sphinx):
         "model_fields",
         "model_post_init",
         "model_computed_fields",
+        "__class_vars__",
+        "__private_attributes__",
+        "__pydantic_complete__",
+        "__pydantic_core_schema__",
+        "__pydantic_custom_init__",
+        "__pydantic_decorators__",
+        "__pydantic_generic_metadata__",
+        "__pydantic_parent_namespace__",
+        "__pydantic_post_init__",
+        "__pydantic_serializer__",
+        "__pydantic_validator__",
         # EthPydanticTypes.
         "__ape_extra_attributes__",
     )


### PR DESCRIPTION
### What I did

noticed a bunch of super low-level pydantic methods in my docs still
also made a `clean` cmd for debugging

### How I did it

ignore them

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
