### PR TITLE
feat: add changelog support to docs builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main]
   release:
-    types: [released]
+    types: [released, edited]
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
 
 jobs:
   docs:
@@ -22,7 +23,7 @@ jobs:
       with:
         python-version: "3.10"
 
-    - run: uv venv --python 3.10 && uv sync --python 3.10  # Is it's own docs dependencies!
+    - run: uv venv --python 3.10 && uv sync --python 3.10 --group docs  # Is it's own docs dependencies!
 
     - name: Add venv to PATH
       run: echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
@@ -33,3 +34,5 @@ jobs:
       uses: ./
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ There are three GitHub events that trigger this action:
 
 3. Pull requests or local development: We ensure a successful build.
 
+When the docs build has access to ``SPHINX_GITHUB_CHANGELOG_TOKEN``, the published site
+also includes a changelog page generated from the repository's GitHub Releases. The docs
+workflow is configured to rebuild on release edits so small changes to older release
+notes can be republished without touching the source tree.
+
 ## GitHub Pages
 
 To set up this action with GitHub pages for the release-workflow to work, first create a branch named `gh-pages` and push it to GitHub.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,7 @@
+Changelog
+=========
+
+.. changelog::
+   :changelog-url: https://docs.apeworx.io/sphinx-ape/stable/changelog.html
+   :github: https://github.com/ApeWorX/sphinx-ape/releases
+   :pypi: https://pypi.org/project/sphinx-ape/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,7 @@
-extensions = ["sphinx_ape"]
+extensions = [
+    "sphinx_ape",
+    "sphinx_github_changelog",
+]
 
 doctest_global_setup = """
 from sphinx_ape.build import BuildMode, DocumentationBuilder

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,8 @@
+.. toctree::
+    :maxdepth: 1
+
+    changelog
+
 .. dynamic-toc-tree::
     :userguides:
         - quickstart

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dependencies = [
 sphinx-ape = "sphinx_ape._cli:cli"
 
 [dependency-groups]
+docs = [
+    "sphinx-github-changelog>=1.7.1,<2",
+]
 test = [
     "pytest>=8.3.2,<9",
     "pytest-mock>=3.14.0,<4",
@@ -68,6 +71,7 @@ dev = [
     "pytest-watch",  # `ptw` test watcher/runner
     "IPython",  # Console for interacting
     "ipdb",  # Debugger (Must use `export PYTHONBREAKPOINT=ipdb.set_trace`)
+    {include-group = "docs"},
     {include-group = "test"},
     {include-group = "lint"},
 ]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -252,3 +252,26 @@ class TestDocumentationBuilder:
         index_content = (builder.latest_path / "index.html").read_text()
         assert "Plugin Python Reference" in index_content
         assert "Core Python Reference" in index_content
+
+    def test_build_preserves_static_toctree_pages(self, temp_path):
+        builder = DocumentationBuilder(mode=BuildMode.LATEST, base_path=temp_path)
+        builder.init()
+        custom_toc = (
+            ".. toctree::\n"
+            "    :maxdepth: 1\n\n"
+            "    changelog\n\n"
+            ".. dynamic-toc-tree::\n"
+            "    :userguides:\n"
+            "        - quickstart\n"
+        )
+        builder.index_docs_file.unlink()
+        builder.index_docs_file.write_text(custom_toc)
+        (builder.docs_path / "changelog.rst").write_text("Changelog\n=========\n\nHello.\n")
+
+        builder.build()
+
+        changelog_path = builder.latest_path / "changelog.html"
+        assert changelog_path.is_file()
+
+        index_content = (builder.latest_path / "index.html").read_text()
+        assert 'href="changelog.html"' in index_content


### PR DESCRIPTION
### What I did

Added a changelog page to the published docs and wired docs builds to refresh it from GitHub Releases.

fixes: #24

### How I did it

- added a docs-only dependency on `sphinx-github-changelog`
- enabled the changelog extension in `docs/conf.py`
- added `docs/changelog.rst` and linked it from the docs index
- updated the docs workflow to install docs dependencies, pass the GitHub token to the changelog builder, and rebuild on `release.edited`
- added a regression test proving static `toctree` pages remain linked alongside the dynamic sphinx-ape table of contents

### How to verify it

```bash
. .venv/bin/activate && pytest tests/test_build.py -q
. .venv/bin/activate && ruff check docs/conf.py tests/test_build.py
. .venv/bin/activate && ruff format --check docs/conf.py tests/test_build.py
. .venv/bin/activate && SPHINX_GITHUB_CHANGELOG_TOKEN="$(gh auth token)" sphinx-ape build .
```

This renders `docs/_build/sphinx-ape/latest/changelog.html` with release data from GitHub Releases.

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
