### PR TITLE
fix: update shibuya to get AI dropdown link fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "click>=8.1.7,<9",  # Script controller framework
     "tomli>=1.2.3,<3",  # For parsing pyproject.toml file
-    "shibuya",  # Sphinx theme
+    "shibuya>=2025.12.17",  # Sphinx theme (requires fix for AI dropdown links)
     "pygments>=2.17.0,<3",  # Needed for the Vyper lexer
     "myst-parser>=4.0.0,<5",  # Parse markdown docs
     "sphinx-click>=6.0.0,<7",  # For documenting CLI


### PR DESCRIPTION
## Summary

Fixes #35

The shibuya theme had a bug where the "help with AI" dropdown generated relative paths (e.g., `../_sources/userguides/quickstart.md.txt`) instead of absolute URLs for the source links. This caused the AI tools (Claude, ChatGPT, etc.) to receive broken links.

## Changes

- Updated the `shibuya` dependency in `pyproject.toml` to require version `>=2025.12.17` which includes the fix for relative link generation.

## Reference

- Upstream fix: https://github.com/lepture/shibuya/issues/103